### PR TITLE
Add a `--params` flag

### DIFF
--- a/cli/interaction.ss
+++ b/cli/interaction.ss
@@ -78,12 +78,8 @@
   (force-output))
 
 (def (ask-application)
-  (let
-    ((apps
-       (map
-        (lambda (app) (cons app app))
-        (get-glow-app-names))))
-    (ask-option "Choose application" apps)))
+  (def apps (get-glow-app-names))
+  (ask-option "Choose application" (map cons apps apps)))
 
 (def (ask-interaction interactions)
   (match interactions

--- a/runtime/glow-path.ss
+++ b/runtime/glow-path.ss
@@ -4,6 +4,7 @@
   :std/getopt :std/iter :std/misc/hash :std/sort :std/misc/string :std/srfi/13
   :std/sugar :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
   :clan/config :clan/path :clan/path-config :clan/string
+  :gerbil/gambit/ports
   :clan/poo/cli)
 
 (def glow-path #f)
@@ -43,7 +44,11 @@
   glow-dapps)
 
 (def (get-glow-app-names)
-  (sort (hash-keys (ensure-glow-dapps)) string<?))
+  (let ((result (sort (hash-keys (ensure-glow-dapps)) string<?)))
+    (with-output-to-port (current-error-port)
+      (lambda ()
+        (displayln "(get-glow-app-names) = " result)))
+    result))
 
 (def options/glow-path
   (make-options [(option 'glow-path "-G" "--glow-path" help: "search path for Glow DApps"

--- a/runtime/glow-path.ss
+++ b/runtime/glow-path.ss
@@ -1,24 +1,24 @@
 (export #t)
 
 (import
-  :std/getopt :std/iter :std/misc/hash :std/sort :std/misc/string :std/srfi/13
+  :std/getopt :std/iter :std/misc/hash :std/misc/string :std/sort :std/misc/string :std/srfi/13
   :std/sugar :clan/cli :clan/config :clan/filesystem :clan/hash :clan/multicall
   :clan/config :clan/path :clan/path-config :clan/string
   :gerbil/gambit/ports
   :clan/poo/cli)
 
+(def glow-install-path (source-path))
 (def glow-path #f)
 (def glow-dapps #f)
 
 (def (default-glow-path)
   [(map (cut subpath <> "glow/dapps") [(xdg-data-home) (xdg-data-dirs) ...]) ...
-   (source-path "dapps")])
+   (subpath glow-install-path "dapps")])
 
 (def (initialize-glow-path! (user-provided #f))
   (set! glow-path (or user-provided
                       (getenv-absolute-paths "GLOW_PATH")
                       (default-glow-path))))
-
 
 (def (for-each-dapp-file f extension: (extension ".glow"))
   (assert! glow-path "You must initialize-glow-path! before you search for dapp files!")
@@ -61,6 +61,11 @@
    getopt: options/glow-path)
   (def apps (hash->list/sort (ensure-glow-dapps) string<?))
   (for-each (lambda (n p) (displayln n "  " p)) (co-pad-strings (map car apps)) (map cdr apps)))
+
+(define-entry-point (show-glow-path)
+  (help: "Show Glow path"
+   getopt: options/glow-path)
+  (displayln (string-join glow-path ":")))
 
 (def (find-dapp-path relpath)
   (find file-exists? (map (cut subpath <> relpath) glow-path)))

--- a/t/buy-sig-integrationtest.ss
+++ b/t/buy-sig-integrationtest.ss
@@ -53,6 +53,7 @@
          (open-process
           [path: "./glow"
            arguments: ["start-interaction"
+                       "--glow-path" (source-path "dapps")
                        "--evm-network" "pet"
                        "--test"
                        "--handshake" "nc -l 3232"
@@ -93,6 +94,7 @@
                     "./" peer-command
                       " --evm-network pet"
                       " --database /tmp/alt-glow-db"
+                      " --glow-path " (source-path "dapps")
                       " --test"
                       " --handshake 'nc localhost 3232'")]]))
 

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -136,6 +136,8 @@
          (key (if (string? answer)
                 answer
                 (car (filter answer (hash-keys options)))))
+         (_ (DBG answer-questions:
+                 question answer key (hash->list/sort options string<?)))
          (option-num (hash-ref/default options key
                                        (cut error "Missing option"
                                             (hash->list/sort options string<?) key))))
@@ -179,17 +181,14 @@
 (def (read-environment)
   ;; Finds the environment logged at the end of a cli run, parses
   ;; it, and returns it as a hash table.
-  (find-first-line
-    (lambda (line) (string=? line "Final environment:")))
   (def table (make-hash-table))
-  (def (read-all)
-    (def line (read-environment-line))
-    (match line
+  (find-first-line (lambda (line) (string=? line "Final environment:")))
+  (let read-all ()
+    (match (read-environment-line)
       ([key value]
        (hash-put! table key value)
        (read-all))
       (_ (void))))
-  (read-all)
   table)
 
 (def (read-environment-line)

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -76,7 +76,10 @@
   (def raw-line (read-line))
   (if (equal? raw-line #!eof)
     #!eof
-    (remove-terminal-control-seqs raw-line)))
+    (let ((line (remove-terminal-control-seqs raw-line)))
+      (with-output-to-port (current-error-port)
+        (lambda () (displayln "Read Line: " line)))
+      line)))
 
 (def (find-first-line matches?)
   ;; Skip past any lines in the input that don't match the predicate `matches?`,

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -9,9 +9,9 @@
 ;; for the purposes of integration testing (for "real" development you
 ;; should instead use programmatic interfaces directly).
 
-(import :std/misc/list)
-(import :std/pregexp)
-(import :gerbil/gambit/ports)
+(import :gerbil/gambit/ports
+        :std/misc/hash :std/misc/list :std/pregexp
+        :clan/exit)
 
 (def (with-io-port port fn)
   ;; Run (fn) with both current input and output ports redirected
@@ -137,7 +137,9 @@
     (if (string? answer)
       answer
       (car (filter answer (hash-keys options)))))
-  (def option-num (hash-ref options key))
+  (def option-num (hash-ref/default options key
+                                    (cut error "Missing option"
+                                         (hash->list/sort options string<?) key)))
   (displayln-now option-num))
 
 (def (supply-parameters params)
@@ -201,3 +203,6 @@
         (def key (read))
         (read) ; skip over the =>
         [key (read)]))))
+
+(abort-on-error? #t)
+(backtrace-on-abort? #t)

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -132,15 +132,14 @@
   ;; The answer can either be a literal string, or a predicate
   ;; indicating whether an answer matches. In the latter case,
   ;; if there is more than one match it is unspecified which is used.
-  (def options (question-options question))
-  (def key
-    (if (string? answer)
-      answer
-      (car (filter answer (hash-keys options)))))
-  (def option-num (hash-ref/default options key
-                                    (cut error "Missing option"
-                                         (hash->list/sort options string<?) key)))
-  (displayln-now option-num))
+  (let* ((options (question-options question))
+         (key (if (string? answer)
+                answer
+                (car (filter answer (hash-keys options)))))
+         (option-num (hash-ref/default options key
+                                       (cut error "Missing option"
+                                            (hash->list/sort options string<?) key))))
+    (displayln-now option-num)))
 
 (def (supply-parameters params)
   (map
@@ -162,7 +161,7 @@
     params))
 
 (def (set-initial-block)
-  ;; Replies to the probpt "Max initial block [...]", using the current
+  ;; Replies to the prompt "Max initial block [...]", using the current
   ;; block number as the selection.
   (def prompt
     (find-first-line

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -93,10 +93,10 @@
       (find-first-line matches?))))
 
 (defstruct question
-  (prompt  ;; The prompt for the question, e.g. "Choose your role:":
-   options ;; A hash table mapping the textual answers to the numeric option
-           ;; (as a string) that must be entered to choose that answer:
-  ))
+  (prompt   ;; The prompt for the question, e.g. "Choose your role:":
+   options) ;; A hash table mapping the textual answers to the numeric option
+            ;; (as a string) that must be entered to choose that answer:
+  transparent: #t)
 
 (def (read-question prompt)
   ;; Look for the provided question prompt in the input, and read in
@@ -138,7 +138,9 @@
                 answer
                 (car (filter answer (hash-keys options)))))
          (_ (DBG answer-questions:
-                 question answer key (hash->list/sort options string<?)))
+                 (question-prompt question)
+                 (hash->list/sort (question-options question) string<?)
+                 answer key (hash->list/sort options string<?)))
          (option-num (hash-ref/default options key
                                        (cut error "Missing option"
                                             (hash->list/sort options string<?) key))))

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -127,6 +127,7 @@
   (apply displayln args)
   (force-output))
 
+(import :clan/debug)
 (def (answer-question question answer)
   ;; Answer a Question object "question" with the provided answer.
   ;; The answer can either be a literal string, or a predicate

--- a/t/cli-integration.ss
+++ b/t/cli-integration.ss
@@ -17,7 +17,7 @@
   ;; Run (fn) with both current input and output ports redirected
   ;; to `port`.
   ;;
-  ;; TODO: this is a more general utiltiy than just interacting with our own
+  ;; TODO: this is a more general utility than just interacting with our own
   ;; CLI; should we push this into gerbil utils or something? maybe something
   ;; similar already exists?
   (with-output-to-port port
@@ -137,10 +137,6 @@
          (key (if (string? answer)
                 answer
                 (car (filter answer (hash-keys options)))))
-         (_ (DBG answer-questions:
-                 (question-prompt question)
-                 (hash->list/sort (question-options question) string<?)
-                 answer key (hash->list/sort options string<?)))
          (option-num (hash-ref/default options key
                                        (cut error "Missing option"
                                             (hash->list/sort options string<?) key))))

--- a/t/coin-flip-integrationtest.ss
+++ b/t/coin-flip-integrationtest.ss
@@ -47,6 +47,7 @@
          (open-process
           [path: "./glow"
            arguments: ["start-interaction"
+                       "--glow-path" (source-path "dapps")
                        "--evm-network" "pet"
                        "--test"
                        "--handshake" "nc -l 3232"]]))
@@ -75,6 +76,7 @@
            arguments:
             ["-c" (string-append
                     "./" peer-command
+                      " --glow-path " (source-path "dapps")
                       " --evm-network pet"
                       " --database /tmp/alt-glow-db"
                       " --test"

--- a/t/coin-flip-integrationtest.ss
+++ b/t/coin-flip-integrationtest.ss
@@ -40,18 +40,21 @@
       (def a-balance-before (eth_getBalance a-address 'latest))
       (def b-balance-before (eth_getBalance b-address 'latest))
 
-      (def proc-a
-        (open-process
+      (def proc-a #f)
+      (def proc-b #f)
+      (try
+       (set! proc-a
+         (open-process
           [path: "./glow"
            arguments: ["start-interaction"
                        "--evm-network" "pet"
                        "--test"
                        "--handshake" "nc -l 3232"]]))
 
-      (def peer-command
-        (with-io-port proc-a
-          (lambda ()
-            (answer-questions
+       (def peer-command
+         (with-io-port proc-a
+           (lambda ()
+             (answer-questions
               [["Choose application:"
                 "coin_flip"]
                ["Choose your identity:"
@@ -60,14 +63,14 @@
                 "A"]
                ["Select address for B:"
                 (lambda (id) (string-prefix? "t/bob " id))]])
-            (supply-parameters
+             (supply-parameters
               [["wagerAmount" wagerAmount]
                ["escrowAmount" escrowAmount]])
-            (set-initial-block)
-            (read-peer-command))))
+             (set-initial-block)
+             (read-peer-command))))
 
-      (def proc-b
-        (open-process
+       (set! proc-b
+         (open-process
           [path: "/bin/sh"
            arguments:
             ["-c" (string-append
@@ -77,46 +80,47 @@
                       " --test"
                       " --handshake 'nc localhost 3232'")]]))
 
-      (def b-environment
-        (with-io-port proc-b
-          (lambda ()
-            (answer-questions
+       (def b-environment
+         (with-io-port proc-b
+           (lambda ()
+             (answer-questions
               [["Choose your identity:"
                 (lambda (id) (string-prefix? "t/bob " id))]
                ["Choose your role:"
                 "B"]])
-            (read-environment))))
+             (read-environment))))
 
-      (def a-environment
-        (with-io-port proc-a read-environment))
+       (def a-environment
+         (with-io-port proc-a read-environment))
 
-      (close-port proc-a)
-      (close-port proc-b)
+       (assert! (equal? a-environment b-environment))
 
-      (assert! (equal? a-environment b-environment))
+       (def a-balance-after (eth_getBalance a-address 'latest))
+       (def b-balance-after (eth_getBalance b-address 'latest))
+       (def randA (hash-get a-environment 'randA))
+       (def randB (hash-get a-environment 'randB))
+       (def a-wins? (even? (bitwise-xor randA randB)))
 
-      (def a-balance-after (eth_getBalance a-address 'latest))
-      (def b-balance-after (eth_getBalance b-address 'latest))
-      (def randA (hash-get a-environment 'randA))
-      (def randB (hash-get a-environment 'randB))
-      (def a-wins? (even? (bitwise-xor randA randB)))
+       (DDT "DApp completed"
+            UInt256 randA
+            UInt256 randB
+            Bool a-wins?
+            (.@ Ether .string<-) a-balance-before
+            (.@ Ether .string<-) b-balance-before
+            (.@ Ether .string<-) a-balance-after
+            (.@ Ether .string<-) b-balance-after)
 
-      (DDT "DApp completed"
-           UInt256 randA
-           UInt256 randB
-           Bool a-wins?
-           (.@ Ether .string<-) a-balance-before
-           (.@ Ether .string<-) b-balance-before
-           (.@ Ether .string<-) a-balance-after
-           (.@ Ether .string<-) b-balance-after)
+       (def gas-allowance (wei<-ether .01))
+       (def a-outcome (if a-wins? wagerAmount (- wagerAmount)))
+       (def b-outcome (if a-wins? (- wagerAmount) wagerAmount))
+       (assert! (<= 0 (- (+ a-balance-before a-outcome) a-balance-after) gas-allowance))
+       (assert! (<= 0 (- (+ b-balance-before b-outcome) b-balance-after) gas-allowance))
 
-      (def gas-allowance (wei<-ether .01))
-      (def a-outcome (if a-wins? wagerAmount (- wagerAmount)))
-      (def b-outcome (if a-wins? (- wagerAmount) wagerAmount))
-      (assert! (<= 0 (- (+ a-balance-before a-outcome) a-balance-after) gas-allowance))
-      (assert! (<= 0 (- (+ b-balance-before b-outcome) b-balance-after) gas-allowance))
-
-      ;; TODO: check the financial outcome of the interaction, too.
-      (check-equal?
+       ;; TODO: check the financial outcome of the interaction, too.
+       (check-equal?
         (hash->list/sort a-environment symbol<?)
-        (hash->list/sort b-environment symbol<?)))))
+        (hash->list/sort b-environment symbol<?))
+
+       (finally
+        (ignore-errors (close-port proc-a))
+        (ignore-errors (close-port proc-b)))))))

--- a/t/rps-simple-integrationtest.ss
+++ b/t/rps-simple-integrationtest.ss
@@ -43,6 +43,7 @@
         (open-process
           [path: "./glow"
            arguments: ["start-interaction"
+                       "--glow-path" (source-path "dapps")
                        "--evm-network" "pet"
                        "--test"
                        "--handshake" "nc -l 3232"]]))
@@ -69,7 +70,8 @@
           [path: "/bin/sh"
            arguments:
             ["-c" (string-append
-                    "./" peer-command
+                      "./" peer-command
+                      " --glow-path " (source-path "dapps")
                       " --evm-network pet"
                       " --database /tmp/alt-glow-db"
                       " --test"

--- a/t/rps-simple-integrationtest.ss
+++ b/t/rps-simple-integrationtest.ss
@@ -36,8 +36,10 @@
     (DBG "DONE")
 
     (test-case "rps_simple executes"
-
-      (def proc-a
+      (def proc-a #f)
+      (def proc-b #f)
+      (try
+       (set! proc-a
         (open-process
           [path: "./glow"
            arguments: ["start-interaction"
@@ -45,10 +47,10 @@
                        "--test"
                        "--handshake" "nc -l 3232"]]))
 
-      (def peer-command
-        (with-io-port proc-a
-          (lambda ()
-            (answer-questions
+       (def peer-command
+         (with-io-port proc-a
+           (lambda ()
+             (answer-questions
               [["Choose application:"
                 "rps_simple"]
                ["Choose your identity:"
@@ -57,13 +59,13 @@
                 "A"]
                ["Select address for B:"
                 (lambda (id) (string-prefix? "t/bob " id))]])
-            (supply-parameters
+             (supply-parameters
               [["wagerAmount" wagerAmount]])
-            (set-initial-block)
-            (read-peer-command))))
+             (set-initial-block)
+             (read-peer-command))))
 
-      (def proc-b
-        (open-process
+       (set! proc-b
+         (open-process
           [path: "/bin/sh"
            arguments:
             ["-c" (string-append
@@ -73,36 +75,36 @@
                       " --test"
                       " --handshake 'nc localhost 3232'")]]))
 
-      (with-io-port proc-b
-        (lambda ()
-          (answer-questions
+       (with-io-port proc-b
+         (lambda ()
+           (answer-questions
             [["Choose your identity:"
               (lambda (id) (string-prefix? "t/bob " id))]
              ["Choose your role:"
               "B"]])))
 
-      (with-io-port proc-a
-        (lambda ()
-          (displayln "2") ; Scissors
-          (force-output)))
+       (with-io-port proc-a
+         (lambda ()
+           (displayln "2") ; Scissors
+           (force-output)))
 
-      (def b-environment
-        (with-io-port proc-b
-          (lambda ()
-            (displayln "1") ; Paper
-            (force-output)
-            (read-environment))))
+       (def b-environment
+         (with-io-port proc-b
+           (lambda ()
+             (displayln "1") ; Paper
+             (force-output)
+             (read-environment))))
 
-      (def a-environment
-        (with-io-port proc-a read-environment))
+       (def a-environment
+         (with-io-port proc-a read-environment))
+       (assert! (equal? a-environment b-environment))
 
-      (close-port proc-a)
-      (close-port proc-b)
-
-      (assert! (equal? a-environment b-environment))
-
-      ;; if A chose scissors, B chose paper, then outcome 2 (A_Wins)
-      (def outcome (hash-get a-environment 'outcome))
-      (display-object
+       ;; if A chose scissors, B chose paper, then outcome 2 (A_Wins)
+       (def outcome (hash-get a-environment 'outcome))
+       (display-object
         ["outcome extracted from contract logs, 0 (B_Wins), 1 (Draw), 2 (A_Wins):" UInt256 outcome])
-      (check-equal? outcome 2))))
+       (check-equal? outcome 2)
+
+       (finally
+        (ignore-errors (close-port proc-a))
+        (ignore-errors (close-port proc-b)))))))


### PR DESCRIPTION
In GitLab by @isd on Apr 11, 2021, 02:50

Per #45; this just does the bare-bones option of accepting a JSON object.

Per discussion with @fare on discord, gerbil's getopt package doesn't currently support flags being specified multiple times, which makes it hard to implement `--param foo=bar --param baz=quux` as discussed, but perhaps we can revisit that if that feature gets pushed upstream; we can talk about if/when we want to shave that yak.

I will likely also add a `--participants` flag as Fare suggested.