### PR TITLE
Store encrypted keys in the contacts database

### DIFF
--- a/cli/contacts.ss
+++ b/cli/contacts.ss
@@ -34,12 +34,13 @@
 
 (def (load-contacts.db)
   (for/collect (contact (list-contacts.db))
-    (.o (:: @ Contact)
-        (cid (hash-ref contact 'cid))
-        (name (hash-ref contact 'name))
-        (identities
-         (for/collect (identity (hash-ref contact 'identities []))
-           (<-json Identity identity))))))
+    (force-object ; for immediate key registration
+     (.o (:: @ Contact)
+         (cid (hash-ref contact 'cid))
+         (name (hash-ref contact 'name))
+         (identities
+          (for/collect (identity (hash-ref contact 'identities []))
+            (<-json Identity identity)))))))
 
 (def (load-contacts contacts-file keypairs-file)
   (load-keypairs from: keypairs-file)

--- a/cli/contacts.ss
+++ b/cli/contacts.ss
@@ -6,7 +6,7 @@
   :clan/poo/brace :clan/poo/cli :clan/poo/io :clan/poo/mop :clan/poo/object :clan/poo/type
   (only-in :clan/poo/number Nat)
   :mukn/ethereum/cli :mukn/ethereum/hex :mukn/ethereum/ethereum :mukn/ethereum/known-addresses
-  (only-in ./identities Identity load-keypairs options/keypairs)
+  (only-in ./identities Identity)
   (rename-in ../contacts/db (add-contact add-contact.db) (list-contacts list-contacts.db)))
 
 (define-type Contact
@@ -42,21 +42,18 @@
           (for/collect (identity (hash-ref contact 'identities []))
             (<-json Identity identity)))))))
 
-(def (load-contacts contacts-file keypairs-file)
-  (load-keypairs from: keypairs-file)
+(def (load-contacts contacts-file)
   (match contacts-file
     ((? string?) (load-contacts.json contacts-file))
     (#f (load-contacts.db))))
 
 (def options/contacts
   (make-options
-   [(flag 'json "-J" "--json" help: "write contacts as JSON")]
-   []
-   [options/keypairs]))
+   [(flag 'json "-J" "--json" help: "write contacts as JSON")]))
 
-(define-entry-point (add-contact name: (name #f)
-                                 json: (json #f)
-                                 keypairs: (keypairs-file #f))
+(define-entry-point (add-contact
+                     name: (name #f)
+                     json: (json #f))
   (help: "Add contact"
    getopt: (make-options
             [(option 'name "-N" "--name" help: "name of contact")]
@@ -68,10 +65,10 @@
       (displayln (string<-json (hash (cid cid) (name name))))
       (displayln "Added contact " name ", cid " cid)))
 
-(define-entry-point (remove-contact cid: (cid #f)
-                                    name: (name #f)
-                                    json: (json #f)
-                                    keypairs: (keypairs-file #f))
+(define-entry-point (remove-contact
+                     cid: (cid #f)
+                     name: (name #f)
+                     json: (json #f))
   (help: "Remove contact"
    getopt: (make-options [(option 'cid "-C" "--cid" help: "contact ID")
                           (option 'name "-N" "--name" help: "name of contact")]
@@ -86,10 +83,9 @@
 
 (define-entry-point (list-contacts
                      contacts: (contacts-file #f)
-                     keypairs: (keypairs-file #f)
                      json: (json #f))
   (help: "List contacts" getopt: options/contacts)
-  (def contacts (sort (load-contacts contacts-file keypairs-file)
+  (def contacts (sort (load-contacts contacts-file)
                       (lambda (c1 c2) (< (.@ c1 cid) (.@ c2 cid)))))
   (if json
       (displayln (string<-json (map (cut json<- Contact <>) contacts)))

--- a/cli/ethereum.ss
+++ b/cli/ethereum.ss
@@ -15,11 +15,14 @@
   :mukn/ethereum/testing :mukn/ethereum/erc20
   ./contacts ./identities)
 
-(define-entry-point (transfer from: (from #f) to: (to #f) value: (value #f)
-                              contacts: (contacts-file #f) keypairs: (keypairs-file #f))
+(define-entry-point (transfer
+                     from: (from #f)
+                     to: (to #f)
+                     value: (value #f)
+                     contacts: (contacts-file #f))
   (help: "Send tokens from one account to the other"
    getopt: (make-options [] [(cut hash-restrict-keys! <> '(from to value))] options/send))
-  (def contacts (load-contacts contacts-file keypairs-file))
+  (def contacts (load-contacts contacts-file))
   (def currency (.@ (ethereum-config) nativeCurrency))
   (def token-symbol (.@ currency symbol))
   (def network (.@ (ethereum-config) network))
@@ -40,14 +43,16 @@
           (0x<-address from) (decimal-string-ether<-wei (eth_getBalance from)) token-symbol
           (0x<-address to) (decimal-string-ether<-wei (eth_getBalance to)) token-symbol))
 
-(define-entry-point (faucet from: (from #f) to: (to #f)
-                     contacts: (contacts-file #f) keypairs: (keypairs-file #f))
+(define-entry-point (faucet
+                     from: (from #f)
+                     to: (to #f)
+                     contacts: (contacts-file #f))
   (help: "Fund some accounts from the network faucet"
    getopt: (make-options []
                          [(cut hash-restrict-keys! <> '(from to value))]
-                         [options/keypairs options/to]))
+                         [options/to]))
   (def-slots (network faucets name nativeCurrency) (ethereum-config))
-  (load-contacts contacts-file keypairs-file)
+  (load-contacts contacts-file)
   (unless to (error "Missing recipient. Please use option --to"))
   (set! to (parse-address to))
   (cond
@@ -91,12 +96,16 @@
   (make-options [(option 'erc20 "-e" "--erc20" help: "Address of ERC20 contract")]
                 [] options/evm-network))
 
-(define-entry-point ($erc20-transfer from: (from #f) erc20: (erc20 #f) to: (to #f) value: (value #f)
-                                     contacts: (contacts-file #f) keypairs: (keypairs-file #f))
+(define-entry-point ($erc20-transfer
+                     from: (from #f)
+                     erc20: (erc20 #f)
+                     to: (to #f)
+                     value: (value #f)
+                     contacts: (contacts-file #f))
   (help: "Send ERC20 tokens from one account to the other"
    getopt: (make-options [] [(cut hash-restrict-keys! <> '(from erc20 to value))]
                          [options/send options/erc20]))
-  (load-contacts contacts-file keypairs-file)
+  (load-contacts contacts-file)
   (def currency (.@ (ethereum-config) nativeCurrency))
   (def token-symbol (.@ currency symbol))
   (def network (.@ (ethereum-config) network))

--- a/cli/interaction.ss
+++ b/cli/interaction.ss
@@ -213,7 +213,6 @@
                      max-initial-block: (max-initial-block #f)
                      timeout-in-blocks: (timeout-in-blocks #f)
                      contacts: (contacts-file #f)
-                     keypairs: (keypairs-file #f)
                      handshake: (handshake #f)
                      params: (params #f)
                      participants: (participants #f))
@@ -244,7 +243,7 @@
              (option 'handshake "-H" "--handshake" default: #f
                      help: "command to use to transfer handshakes")]
             [(lambda (opt) (hash-remove! opt 'test))]
-            [options/glow-path options/contacts options/keypairs
+            [options/glow-path options/contacts
              options/evm-network options/database options/test options/backtrace]))
   (def options
        (hash
@@ -256,7 +255,7 @@
          (timeout-in-blocks timeout-in-blocks)
          (role role)))
   (displayln)
-  (def contacts (load-contacts contacts-file keypairs-file))
+  (def contacts (load-contacts contacts-file))
   (defvalues (agreement selected-role)
     (if agreement-json-string
       (start-interaction/with-agreement options (<-json InteractionAgreement (json<-string agreement-json-string)))

--- a/contacts/db.ss
+++ b/contacts/db.ss
@@ -18,7 +18,8 @@
  (only-in :std/srfi/1 append-map first)
  :std/sugar
  :std/text/json
- (only-in :mukn/ethereum/network-config ethereum-networks))
+ (only-in :mukn/ethereum/network-config ethereum-networks)
+ (only-in ./keys secret-key-ciphers))
 
 ;; The global contacts database connection handle.
 (def contact-db #f)
@@ -96,11 +97,10 @@
     (finally (sql-txn-commit contact-db))))
 
 ;; Import supported AES ciphers.
-;; TODO: XTS and GCM modes are not yet supported by Gerbil's std/crypto/cipher.
 (def (import-ciphers)
   (let ((stmt (sql-prepare contact-db "INSERT INTO cipher (name) VALUES ($1)")))
-    (for ((cipher (list cipher::aes-256-cbc cipher::aes-256-ctr)))
-      (sql-bind stmt (cipher-name cipher))
+    (for ((cipher-name (hash-keys secret-key-ciphers)))
+      (sql-bind stmt cipher-name)
       (sql-exec stmt))))
 
 ;; Import known Ethereum networks.

--- a/contacts/keys.ss
+++ b/contacts/keys.ss
@@ -1,0 +1,71 @@
+;;;; Only encrypted secret keys are stored in the database.
+;;;; The global encryption key is stored in a separate file.
+
+(export #t)
+
+(import
+ :gerbil/gambit/bytes :gerbil/gambit/os
+ :std/crypto
+ :clan/config)
+
+;; The key used to encrypt all secret keys.
+(def global-key #f)
+(def (global-key-path)
+  (xdg-config-home "glow" "global.key"))
+
+;; The default cipher used to encrypt secret keys.
+;; TODO: cipher::aes-256-gcm would be a better choice since it supports
+;; authentication, but Gerbil's crypto drivers can't handle it yet.
+(def secret-key-cipher cipher::aes-256-ctr)
+
+;; Supported ciphers, indexed by name.
+(def secret-key-ciphers
+  (list->hash-table
+   (map (lambda (cipher) (cons (cipher-name cipher) cipher))
+        [cipher::aes-256-ctr])))
+
+;; Read some random bytes from the operating system.
+;; These bytes are used directly as secret keys and IVs,
+;; so they had better have high entropy.
+(def (read-random-bytes n-bytes)
+  (call-with-input-file "/dev/urandom"
+    (cut read-bytes n-bytes <>)))
+
+;; Read or create a global key, stored as raw bytes on disk.
+;; TODO: Obtain key from an OS-level key management service.
+(def (ensure-global-key!)
+  (unless global-key
+    (let ((key-length (cipher-key-length secret-key-cipher))
+          (key-path (global-key-path)))
+      (cond ((file-exists? key-path)
+             (if (= key-length (file-size key-path))
+                 (set! global-key (call-with-input-file key-path
+                                    (cut read-bytes key-length <>)))
+                 (error "Global key length does not match secret key cipher"
+                        (cipher-name secret-key-cipher))))
+            (else
+             (set! global-key (read-random-bytes key-length))
+             (with-output-to-file [path: (global-key-path)
+                                   permissions: #o600]
+               (lambda ()
+                 (write-bytes global-key)))))))
+  global-key)
+
+;; Encrypt a secret key with the global key and a random IV (nonce).
+(def (encrypt-secret-key secret-key)
+  (let* ((cipher (and secret-key secret-key-cipher
+                      (make-cipher secret-key-cipher)))
+         (iv (and cipher
+                  (read-random-bytes (cipher-iv-length cipher)))))
+    (if (and cipher iv secret-key)
+        (values (encrypt cipher (ensure-global-key!) iv secret-key) iv)
+        (values #f #f))))
+
+;; Decrypt a secret key with the global key.
+(def (decrypt-secret-key cipher-name iv secret-key)
+  (let ((cipher (and cipher-name iv secret-key
+                     (hash-key? secret-key-ciphers cipher-name)
+                     (make-cipher (hash-ref secret-key-ciphers cipher-name)))))
+    (if cipher
+        (decrypt cipher (ensure-global-key!) iv secret-key)
+        (error "Cannot decrypt secret key"))))


### PR DESCRIPTION
In GitLab by @plotnick on Aug 12, 2021, 07:11

Keeps a global (master) 32-byte key in `~/.config/glow/global.key` that is used to encrypt and decrypt secret keys associated with identities and stored in `~/.config/glow/db/contacts.db`. We currently use `AES-256-CTR` with a random IV, but would like to move to `AES-256-GCM`.